### PR TITLE
Fixes

### DIFF
--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -785,6 +785,10 @@ class Controller
                 $this->_f3->set("stateWarning", "You have more than two states set for a checkbox item. Checkboxes will only use the item's first two states.");
             }
         }
+        // Check if an item has more than one tutor state
+        if ($this->_db->getStateCount($itemId, "tutor") > 1) {
+            $this->_f3->set("stateWarning", "You have two or more states set by the tutor. Having multiple states set by the tutor can result errors displaying the tutor's checklist. If you need tutors to take another action, consider adding another item instead.");
+        }
 
 
         $this->_f3->set("item", $this->_db->getItem($itemId));

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -125,6 +125,8 @@ class Controller
             $this->_db->setCurrentYear($_POST["current_year"]);
         } else if (isset($_POST["user_id"])) {
             $this->_db->importUser($_POST["user_id"]);
+        } else if (isset($_POST["remove"])) {
+            $this->_db->removeFromYear($_POST["tutorYear_id"]);
         } else if (isset($_POST['subject']) && isset($_POST['body'])) { //updating default email info
             $this->_mail->setSubject($_POST['subject']);
             $this->_mail->setBody($_POST['body']);

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -214,7 +214,7 @@ class Controller
         }
 
         //this is for building up a navbar
-        $this->navBuilder(array('Form' => '../form/' . $param['userId'], 'Logout' => '../logout'), array('../styles/checklist.css')
+        $this->navBuilder(array('Profile' => '../form/' . $param['userId'], 'Logout' => '../logout'), array('../styles/checklist.css')
             , 'Tutor Checklist');
 
         //get the current year
@@ -251,7 +251,7 @@ class Controller
 
         //this is for building up a navbar
         $this->navBuilder(array('Checklist' => '../checklist/' . $param["id"], 'Logout' => '../logout')
-            , array('../styles/formStyle.css'), 'Onboarding Form');
+            , array('../styles/formStyle.css'), 'Profile');
 
         global $dirName;
         //retrieving data form database

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -96,8 +96,10 @@ class Controller
     {
         if (isset($_POST["stateId"])) {
             $this->_db->updateItemTutorYearSelect($_POST["itemId"], $_POST["tutorYearId"], $_POST["stateId"]);
+            echo $this->_db->getState($_POST["stateId"])["state_is_done"];
         } else if (isset($_POST["stateOrder"])) {
             $this->_db->updateItemTutorYearCheck($_POST["itemId"], $_POST["tutorYearId"], $_POST["stateOrder"]);
+            echo $this->_db->getStateByOrder($_POST["itemId"], $_POST["stateOrder"])["state_is_done"];
         } else if (isset($_POST["email"])) {
             if ($this->_val->uniqueEmail($_POST["email"]) && $this->_val->validEmail($_POST["email"])) {
                 //creating temp password and add new tutor

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -126,7 +126,13 @@ class Controller
         } else if (isset($_POST["current_year"])) {
             $this->_db->setCurrentYear($_POST["current_year"]);
         } else if (isset($_POST["user_id"])) {
-            $this->_db->importUser($_POST["user_id"]);
+            // check if user already exists in this year
+            if ($this->_db->getTutorYear($_POST["user_id"]) == NULL) {
+                $this->_db->importUser($_POST["user_id"]);
+                echo "true";
+            } else {
+                echo "Tutor already exists in the current year";
+            }
         } else if (isset($_POST["remove"])) {
             $this->_db->removeFromYear($_POST["tutorYear_id"]);
         } else if (isset($_POST['subject']) && isset($_POST['body'])) { //updating default email info
@@ -523,7 +529,7 @@ class Controller
         $this->_f3->set("ssn", $this->decryption($tutor["tutor_ssn"]));
         $currentYear = $this->_db->getYearId($param['id']);
         //get the all the files of current year uploaded by tutors
-        $this->_f3->set("filesToDownload", $this->_db->getItemTutor($currentYear,$param['id']));
+        $this->_f3->set("filesToDownload", $this->_db->getItemTutor($currentYear, $param['id']));
 
         //let admin download the tutor's image
         if (isset($_GET['download'])) {

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -754,7 +754,6 @@ class Controller
         // Error messages for delete state
         if (isset($_POST["stateDelete"])) {
             if ($defaults < 1) {
-                // There must be at least one default state set
                 $this->_f3->set("defaultError", "You must have a default state set before deleting this state!");
             } else if ($defaults == 1 && $_POST["stateSetBy"] == "default") {
                 // Error for if the user is trying to delete the only default state
@@ -784,7 +783,7 @@ class Controller
 
         // Other state warnings
 
-        // Check if the item has more
+        // Check if the item has more than 2 items on a checkbox
         if ($this->_db->getItem($itemId)["item_type"] == "checkbox") {
             if ($this->_db->getMaxState($itemId) > 2) {
                 $this->_f3->set("stateWarning", "You have more than two states set for a checkbox item. Checkboxes will only use the item's first two states.");
@@ -793,6 +792,10 @@ class Controller
         // Check if an item has more than one tutor state
         if ($this->_db->getStateCount($itemId, "tutor") > 1) {
             $this->_f3->set("stateWarning", "You have two or more states set by the tutor. Having multiple states set by the tutor can result errors displaying the tutor's checklist. If you need tutors to take another action, consider adding another item instead.");
+        }
+
+        if ($this->_db->getStateCount($itemId, "all") <= 1) {
+            $this->_f3->set("stateWarning", "Items should have at least 2 states.");
         }
 
 

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -771,6 +771,8 @@ class Controller
             }
         }
 
+        $defaults = $this->_db->getStateCount($itemId, "default");
+
         // Default state warnings
         if ($defaults > 1) {
             // More than one default state warning

--- a/model/Database.php
+++ b/model/Database.php
@@ -105,6 +105,8 @@ class Database
         $sql = "UPDATE ItemTutorYear SET state_id = ? WHERE item_id = ? AND tutorYear_id = ?";
         $statement = $this->_dbh->prepare($sql);
         $statement->execute([$stateId, $itemId, $tutorYearId]);
+
+        return "true";
     }
 
     /**

--- a/model/Database.php
+++ b/model/Database.php
@@ -1087,4 +1087,23 @@ class Database
         $statement->execute([$userId]);
         return $statement->fetch(PDO::FETCH_ASSOC)['tutorYear_id'];
     }
+
+    /**
+     * Delete the given tutor year data
+     *
+     * @param int $tutorYearId The tutorYearId of the tutor to be deleted
+     * @author Keller Flint
+     */
+    function removeFromYear($tutorYearId)
+    {
+        // delete item data for tutorYear id
+        $sql = "DELETE FROM ItemTutorYear WHERE tutorYear_id = ?";
+        $statement = $this->_dbh->prepare($sql);
+        $statement->execute([$tutorYearId]);
+
+        // delete user data from tutorYear id
+        $sql = "DELETE FROM TutorYear WHERE tutorYear_id = ?";
+        $statement = $this->_dbh->prepare($sql);
+        $statement->execute([$tutorYearId]);
+    }
 }

--- a/model/Database.php
+++ b/model/Database.php
@@ -794,10 +794,18 @@ class Database
      */
     function getStateCount($itemId, $state)
     {
-        $sql = "SELECT count(state_set_by) AS count FROM State WHERE item_id = ? AND state_set_by = ?;";
-        $statement = $this->_dbh->prepare($sql);
-        $statement->execute([$itemId, $state]);
-        return $statement->fetch(PDO::FETCH_ASSOC)["count"];
+        $sql = "";
+        if ($state == "all") {
+            $sql = "SELECT count(state_set_by) AS count FROM State WHERE item_id = ?";
+            $statement = $this->_dbh->prepare($sql);
+            $statement->execute([$itemId]);
+            return $statement->fetch(PDO::FETCH_ASSOC)["count"];
+        } else {
+            $sql = "SELECT count(state_set_by) AS count FROM State WHERE item_id = ? AND state_set_by = ?";
+            $statement = $this->_dbh->prepare($sql);
+            $statement->execute([$itemId, $state]);
+            return $statement->fetch(PDO::FETCH_ASSOC)["count"];
+        }
     }
 
     /**

--- a/scripts/tutorsScript.js
+++ b/scripts/tutorsScript.js
@@ -19,7 +19,7 @@ $(".checkbox-big").on("click", function () {
     let stateOrder = $(this).is(":checked") ? 2 : 1;
 
     // Update database
-    updateCheckbox(itemId, tutorYearId, stateOrder);
+    updateCheckbox($(this), itemId, tutorYearId, stateOrder);
 
 });
 
@@ -32,39 +32,45 @@ $(".tutor-select").on("change", function () {
     let stateId = $(this).val();
 
     // Update database
-    updateSelect(itemId, tutorYearId, stateId);
+    updateSelect($(this), itemId, tutorYearId, stateId);
 
 });
 
 /**
  * Updates selects via ajax
  *
+ * @param element The JQuery object that was clicked on
  * @param itemId The id of the item being updated
  * @param tutorYearId The id of the tutor year being updated
  * @param stateId The id of the state the item is being updated to
  * @author Keller Flint
  */
-function updateSelect(itemId, tutorYearId, stateId) {
+function updateSelect(element, itemId, tutorYearId, stateId) {
     $.post("../tutorsAjax", {
         itemId: itemId,
         tutorYearId: tutorYearId,
         stateId: stateId
+    }, function (result) {
+        element.attr("data-is-done", result);
     });
 }
 
 /**
  * Updates checkboxes via ajax
  *
+ * @param element The JQuery object that was clicked on
  * @param itemId The id of the item being updated
  * @param tutorYearId The id of the tutor year being updated
  * @param stateOrder The order of the state the item is being updated to
  * @author Keller Flint
  */
-function updateCheckbox(itemId, tutorYearId, stateOrder) {
+function updateCheckbox(element, itemId, tutorYearId, stateOrder) {
     $.post("../tutorsAjax", {
         itemId: itemId,
         tutorYearId: tutorYearId,
         stateOrder: stateOrder
+    }, function (result) {
+        element.attr("data-is-done", result);
     });
 }
 
@@ -336,8 +342,9 @@ $("#filter-incomplete").on("click", function () {
         let id = $(this).attr("id");
         let doneArray = [];
         $("#" + id + " .item-input").each(function () {
-            doneArray.push($(this).data("is-done"));
+            doneArray.push(parseInt($(this).attr("data-is-done")));
         });
+        console.log(doneArray);
         if (!doneArray.includes(0)) {
             $(this).hide();
         }
@@ -354,8 +361,9 @@ $("#filter-complete").on("click", function () {
         let id = $(this).attr("id");
         let doneArray = [];
         $("#" + id + " .item-input").each(function () {
-            doneArray.push($(this).data("is-done"));
+            doneArray.push(parseInt($(this).attr("data-is-done")));
         });
+        console.log(doneArray);
         if (doneArray.includes(0)) {
             $(this).hide();
         }

--- a/scripts/tutorsScript.js
+++ b/scripts/tutorsScript.js
@@ -146,10 +146,10 @@ $(".delete").on("click", function () {
         $.post("../tutorsAjax", {
             delete: true,
             user_id: user_id
+        }, function () {
+            let year = $("#year-current").data("year");
+            window.location.href = ("../tutors/" + year);
         });
-
-        let year = $("#year-current").data("year");
-        window.location.href = ("../tutors/" + year);
     }
 });
 
@@ -162,12 +162,13 @@ $(".import").on("click", function () {
         // ajax importing
         $.post("../tutorsAjax", {
             user_id: user_id
-        });
-        //hide Import button after displaying success message
-        let results = confirm("Tutor imported successfully ");
-        if (results) {
+        }, function () {
+            //hide Import button after displaying success message
+            alert("Tutor imported successfully ");
             $(".import").hide();
-        }
+            //TODO error message if user already exists in that year
+        });
+
     }
 });
 
@@ -229,7 +230,7 @@ $.fn.fileUploader = function (filesToUpload) {
                         console.log(response);
                     } else if (response == 0) {
                         alert('Changes not saved');
-                    } else if (response ==2) {
+                    } else if (response == 2) {
                         alert("File Already Exists")
                     }
                 }

--- a/scripts/tutorsScript.js
+++ b/scripts/tutorsScript.js
@@ -187,11 +187,14 @@ $(".import").on("click", function () {
         // ajax importing
         $.post("../tutorsAjax", {
             user_id: user_id
-        }, function () {
+        }, function (result) {
             //hide Import button after displaying success message
-            alert("Tutor imported successfully ");
-            $(".import").hide();
-            //TODO error message if user already exists in that year
+            if (result === "true") {
+                $(".import").hide();
+            } else {
+                alert("Import failed: " + result);
+            }
+
         });
 
     }

--- a/scripts/tutorsScript.js
+++ b/scripts/tutorsScript.js
@@ -118,28 +118,47 @@ $(".year-change").on("click", function () {
 $(window).on("click", function () {
     $(".delete").addClass("d-none");
     $(".import").addClass("d-none");
+    $(".remove").addClass("d-none");
 });
 
-// show delete and import buttons on email click
+// show delete, remove and import buttons on email click
 $(".email").on("click", function (event) {
 
     // hide any open buttons
     $(".delete").addClass("d-none");
     $(".import").addClass("d-none");
+    $(".remove").addClass("d-none");
 
     // show current buttons
     $(this).find(".delete").removeClass("d-none");
     $(this).find(".import").removeClass("d-none");
+    $(this).find(".remove").removeClass("d-none");
 
     // stop window event propagation to keep the window event listener from hiding the button again
     event.stopPropagation();
+});
+
+// Event listener for remove button clicked
+$(".remove").on("click", function () {
+    let result = confirm("Are you sure you want to remove this user and all their data for this year?");
+    if (result) {
+        let tutorYear_id = $(this).data("tutoryearid");
+
+        // ajax deletion
+        $.post("../tutorsAjax", {
+            remove: true,
+            tutorYear_id: tutorYear_id
+        }, function () {
+            let year = $("#year-current").data("year");
+            window.location.href = ("../tutors/" + year);
+        });
+    }
 });
 
 // Event listener for delete button clicked
 $(".delete").on("click", function () {
     let result = confirm("Are you sure you want to delete this user and all data associated with them?");
     if (result) {
-
         let user_id = $(this).data("userid");
 
         // ajax deletion

--- a/styles/itemEditStyle.css
+++ b/styles/itemEditStyle.css
@@ -8,6 +8,10 @@
     margin-left: 25%;
 }
 
+.edit-state {
+    height: 380px;
+}
+
 .move {
     width: 40px;
 }

--- a/views/itemEdit.html
+++ b/views/itemEdit.html
@@ -196,11 +196,11 @@ Page to create, edit and delete items in the table
                     </button>
                 </check>
                 <check if="{{ @state['state_order'] != @maxState }}">
-                    <button type="submit" class="btn btn-white m-3" name="moveDown" value="moveDown"><img class="move"
-                                                                                                          src="../styles/images/down.svg">
+                    <button type="submit" class="btn btn-white m-3" name="moveDown" value="moveDown"><img
+                            class="move"
+                            src="../styles/images/down.svg">
                     </button>
                 </check>
-
             </form>
         </repeat>
 

--- a/views/itemEdit.html
+++ b/views/itemEdit.html
@@ -98,6 +98,9 @@ Page to create, edit and delete items in the table
                     <check if="{{ isset(@defaultWarning) }}">
                         <h2 class="text-warning">{{ @defaultWarning }}</h2>
                     </check>
+                    <check if="{{ @stateWarning }}">
+                        <h2 class="text-warning">{{ @stateWarning }}</h2>
+                    </check>
                 </false>
             </check>
         </check>

--- a/views/itemEdit.html
+++ b/views/itemEdit.html
@@ -57,7 +57,8 @@ Page to create, edit and delete items in the table
             <div class="form-group w-100 text-left">
                 <check if="{{ isset(@item['item_file']) }}">
                     <label>Current File</label><br>
-                    <a href="{{ @item['item_file'] }}">Download {{ @item['item_file'] }} </a>
+                    <a href=" ../uploads/{{ @item['item_file'] }}" download="{{ @item['item_file'] }}">Download {{
+                        @item['item_file'] }} </a>
                     <button type="submit" class="btn btn-warning" name="remove" value="remove">Remove</button>
                 </check>
             </div>

--- a/views/tutors.html
+++ b/views/tutors.html
@@ -65,6 +65,10 @@ Page for admin viewing and management of tutor onboarding data.
                                 Import
                             </button>
                         </check>
+                        <button class="btn btn-warning d-none remove"
+                                data-tutoryearid="{{ @tutorData['info']['tutorYear_id'] }}">
+                            Remove
+                        </button>
                         <button class="btn btn-danger d-none delete" data-userid="{{ @tutorData['info']['user_id'] }}">
                             Delete
                         </button>

--- a/views/tutors.html
+++ b/views/tutors.html
@@ -118,12 +118,13 @@ Page for admin viewing and management of tutor onboarding data.
                                         <repeat group="{{ @items[@column['item_id']]['states'] }}" value="{{ @value }}">
                                             <check if="{{ @value['state_id'] == @column['state_id'] }}">
                                                 <true>
-                                                    <option value="{{ @value['state_id'] }}" selected>{{
-                                                        @value['state_name'] }}
+                                                    <option value="{{ @value['state_id'] }}" selected>
+                                                        {{ @value['state_name'] }}
                                                     </option>
                                                 </true>
                                                 <false>
-                                                    <option value="{{ @value['state_id'] }}">{{ @value['state_name'] }}
+                                                    <option value="{{ @value['state_id'] }}">
+                                                        {{ @value['state_name'] }}
                                                     </option>
                                                 </false>
                                             </check>


### PR DESCRIPTION
Lots of bug fixes for the tutor table and item/state editing:
* Fixed bug causing itemEdit files to redirect rather than download
* Fixed bug causing deletion not to show even after page reload
* Added warnings for more than 2 states on a checkbox item
* Added warnings for multiple tutor states on the same item
* Fixed incorrect multiple default states warning after deleting  all but one default state
* Updated "form" to "profile"
* Fixed display error (with the save and delete buttons) when only one state exists for an item
* Added warning for too few states on an item
* Fixed bug causing filtering buttons not to work until after a page reload when items are updated
* Fixed bug causing tutors to be imported into the current year multiple times
* Added fail messages for importing user's that already exist it the current year
* Added removing tutors from a year in addition to the option for deleting them all together